### PR TITLE
4291 needs access to Tiltakspenger in Kaka.

### DIFF
--- a/src/main/kotlin/no/nav/klage/kodeverk/Type.kt
+++ b/src/main/kotlin/no/nav/klage/kodeverk/Type.kt
@@ -8,7 +8,7 @@ enum class Type(override val id: String, override val navn: String, override val
     KLAGE("1", "Klage", "Klage"),
     ANKE("2", "Anke", "Anke"),
     ANKE_I_TRYGDERETTEN("3", "Anke i Trygderetten", "Anke i Trygderetten"),
-    BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET("4", "Behandling etter Trygderetten opphevet", "Behandling etter Trygderetten opphevet"),
+//    BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET("4", "Behandling etter Trygderetten opphevet", "Behandling etter Trygderetten opphevet"),
     ;
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/klage/kodeverk/TypeTilUtfall.kt
+++ b/src/main/kotlin/no/nav/klage/kodeverk/TypeTilUtfall.kt
@@ -29,13 +29,13 @@ val typeTilUtfall = mapOf(
         HEVET,
         HENVIST,
     ),
-    Type.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET to setOf(
-        TRUKKET,
-        RETUR,
-        OPPHEVET,
-        MEDHOLD,
-        DELVIS_MEDHOLD,
-        STADFESTELSE,
-        AVVIST,
-    ),
+//    Type.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET to setOf(
+//        TRUKKET,
+//        RETUR,
+//        OPPHEVET,
+//        MEDHOLD,
+//        DELVIS_MEDHOLD,
+//        STADFESTELSE,
+//        AVVIST,
+//    ),
 )

--- a/src/main/kotlin/no/nav/klage/kodeverk/YtelseTilKlageenheter.kt
+++ b/src/main/kotlin/no/nav/klage/kodeverk/YtelseTilKlageenheter.kt
@@ -178,6 +178,7 @@ val ytelseTilKlageenheter = mapOf(
     ),
     Ytelse.TIL_TIP to setOf(
         E4250,
+        E4291,
         E2103
     ),
     Ytelse.GEN_GEN to setOf(


### PR DESCRIPTION
Since this goes into production, we need to hide the new `type` unfortunately.